### PR TITLE
ECOM-479 eCommerce - Tax settings - Germany - VAT update for 2020

### DIFF
--- a/resources/tax_type/de_vat.json
+++ b/resources/tax_type/de_vat.json
@@ -13,7 +13,13 @@
                 {
                     "id": "de_vat_standard_2007",
                     "amount": 0.19,
-                    "start_date": "2007-01-01"
+                    "start_date": "2007-01-01",
+                    "end_date": "2020-06-30"
+                },
+                {
+                    "id": "de_vat_standard_2020",
+                    "amount": 0.16,
+                    "start_date": "2020-07-01"
                 }
             ]
         },
@@ -24,7 +30,13 @@
                 {
                     "id": "de_vat_reduced_1983",
                     "amount": 0.07,
-                    "start_date": "1983-07-01"
+                    "start_date": "1983-07-01",
+                    "end_date": "2020-06-30"
+                },
+                {
+                    "id": "de_vat_reduced_2020",
+                    "amount": 0.05,
+                    "start_date": "2020-07-01"
                 }
             ]
         }

--- a/resources/tax_type/gr_vat.json
+++ b/resources/tax_type/gr_vat.json
@@ -25,7 +25,13 @@
                 {
                     "id": "gr_vat_standard_2010_07",
                     "amount": 0.23,
-                    "start_date": "2010-07-01"
+                    "start_date": "2010-07-01",
+                    "end_date": "2016-05-31"
+                },
+                {
+                    "id": "gr_vat_standard_2016_06",
+                    "amount": 0.24,
+                    "start_date": "2016-06-01"
                 }
             ]
         },

--- a/resources/tax_type/nl_vat.json
+++ b/resources/tax_type/nl_vat.json
@@ -30,7 +30,13 @@
                 {
                     "id": "nl_vat_reduced_1986",
                     "amount": 0.06,
-                    "start_date": "1986-10-01"
+                    "start_date": "1986-10-01",
+                    "end_date": "2018-12-31"
+                },
+                {
+                    "id": "nl_vat_reduced_2019",
+                    "amount": 0.09,
+                    "start_date": "2019-01-01"
                 }
             ]
         }


### PR DESCRIPTION
As far as I can tell, the tax rates are just json files and changing any rate should not affect any functionality. I can see that such changes were made before as well in https://github.com/monosolutions/tax/commit/e08219efd13576ddb5ccf7cd17a3e278382e4ce3

 - https://monosupport.atlassian.net/browse/ECOM-479