### PR TITLE
(ECOM-554) Tax rate 19% again | German Covid relaxation period is over

### DIFF
--- a/resources/tax_type/de_vat.json
+++ b/resources/tax_type/de_vat.json
@@ -19,7 +19,13 @@
                 {
                     "id": "de_vat_standard_2020",
                     "amount": 0.16,
-                    "start_date": "2020-07-01"
+                    "start_date": "2020-07-01",
+                    "end_date": "2021-01-01"
+                },
+                {
+                    "id": "de_vat_standard_2021",
+                    "amount": 0.19,
+                    "start_date": "2021-01-01"
                 }
             ]
         },


### PR DESCRIPTION
Update the taxes for Germany back to 19%