### PR TITLE
(ECOM-555) German Covid relaxation period is over - tax rate for food…

### DIFF
--- a/resources/tax_type/de_vat.json
+++ b/resources/tax_type/de_vat.json
@@ -42,7 +42,13 @@
                 {
                     "id": "de_vat_reduced_2020",
                     "amount": 0.05,
-                    "start_date": "2020-07-01"
+                    "start_date": "2020-07-01",
+                    "end_date": "2020-12-31"
+                },
+                {
+                    "id": "de_vat_reduced_2021",
+                    "amount": 0.07,
+                    "start_date": "2021-01-01"
                 }
             ]
         }


### PR DESCRIPTION
…,etc should be changed to 7% from 5%

The reduced VAT in Germany for 2021 is back to 7% after the Covid relaxation period ended in 2020